### PR TITLE
Leave bravado core at fixed version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "Programming Language :: Python :: 3.6",
     ],
     install_requires=[
-        "bravado-core >= 4.2.2",
+        "bravado-core == 4.9.1",
         "python-dateutil",
         "pyyaml",
         "requests >= 2",


### PR DESCRIPTION
The latest release of bravado core breaks this.

Likely at this line: https://github.com/Yelp/bravado/blob/master/bravado/client.py#L264
We see the following warning:/usr/local/lib/python3.4/dist-packages/bravado_core/spec.py:144: Warning: config also_return_response is been removed because is not a recognized config key
  category=Warning